### PR TITLE
implicit resume-host-expansion

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (provide (all-from-out "private/syntax/interface.rkt")
+         with-reference-compilers
          (for-syntax
           number
           expr
@@ -9,8 +10,6 @@
           in-space
           ~space-literal
 
-          resume-host-expansion
-          
           compiled-ids
           compile-reference
           compile-binder!

--- a/private/runtime/compile.rkt
+++ b/private/runtime/compile.rkt
@@ -103,7 +103,7 @@
            v))])))
 
 (define-syntax #%host-expression
-  (let ([who 'host-expr])
+  (let ([who '#%host-expression])
     (syntax-parser
       [(_ e:expr)
        (unless (suspension? this-syntax)

--- a/private/runtime/compile.rkt
+++ b/private/runtime/compile.rkt
@@ -1,9 +1,9 @@
 #lang racket/base
 
-(provide (for-syntax binding-as-rkt
+(provide #%host-expression
+         with-reference-compilers
+         (for-syntax binding-as-rkt
                      make-suspension
-  
-                     resume-host-expansion
 
                      mutable-reference-compiler
                      immutable-reference-compiler))
@@ -47,44 +47,14 @@
 
     ; wrap ctx in a pair because #f is valid as ctx but not as a syntax
     ; property value.
-    (syntax-property stx suspension-property-key (list ctx)))
+    (syntax-property #`(#%host-expression #,stx) suspension-property-key (list ctx)))
 
   (define (suspension? stx)
     (not (not (and (syntax? stx)
                    (syntax-property stx suspension-property-key)))))
-  
-  (struct closed-suspension [stx ctx compile])
 
-  (define current-binding-compilers
+  (define current-reference-compilers
     (make-parameter #f))
-
-
-  (define-syntax resume-host-expansion
-    (syntax-parser
-      [(_ stx-e:expr
-          (~optional (~seq #:reference-compilers
-                           ([bclass:id t-e:expr] ...))
-                     #:defaults ([(bclass 1) '()] [(t-e 1) '()])))
-       #'(resume-host-expansion-rt
-          stx-e
-          (list (quote-syntax bclass) ...) (list t-e ...))]))
-  
-  (define/who (resume-host-expansion-rt stx ks vs)
-    (check who suspension? stx)
-
-    (define binding-compilers
-      (for/fold ([env (make-immutable-free-id-table)])
-                ([k ks]
-                 [v vs])
-        ; TODO make this something more general once we allow arbitrary structs
-        ; as compilers like match expanders.
-        (check who (disjoin procedure? set!-transformer?)
-               #:contract "(or/c (-> syntax? syntax?) set!-transformer?)"
-               v)
-        (free-id-table-set env k v)))
-    
-    (define ctx (car (syntax-property stx suspension-property-key)))
-    #`(expand-suspension #,(closed-suspension stx ctx binding-compilers)))
 
 
   (define (binding-as-rkt bclass-id description)
@@ -97,11 +67,11 @@
           " may not be used as a racket expression")
          stx))
       
-      (when (not (current-binding-compilers))
+      (when (not (current-reference-compilers))
         (error-as-rkt))
       
       (let ([compile (free-id-table-ref
-                      (current-binding-compilers) bclass-id
+                      (current-reference-compilers) bclass-id
                       error-as-rkt)])
         (if (set!-transformer? compile)
             ((set!-transformer-procedure compile) stx)
@@ -110,12 +80,36 @@
                (raise-syntax-error #f (format "the reference compiler for ~a does not support set!" s) stx #'x)]
               [_ (compile stx)]))))))
 
-(define-syntax expand-suspension
-  (syntax-parser
-    [(_ s)
-     (match-define (closed-suspension stx ctx binding-compilers) (syntax-e #'s))
-     (parameterize ([current-binding-compilers binding-compilers])
-       (local-expand (flip-intro-scope stx)
+(define-syntax with-reference-compilers
+  (let ([who 'with-reference-compilers])
+    (syntax-parser
+      [(_ ([bclass:id t-e:expr] ...) body ...+)
+       (define binding-compilers
+         (for/fold ([env (make-immutable-free-id-table)])
+                   ([k (attribute bclass)]
+                    [t-e (attribute t-e)])
+           (define v (eval-transformer t-e))
+           ; TODO make this something more general once we allow arbitrary structs
+           ; as compilers like match expanders.
+           (check who (disjoin procedure? set!-transformer?)
+                  #:contract "(or/c (-> syntax? syntax?) set!-transformer?)"
+                  v)
+           (free-id-table-set env k v)))
+       (parameterize ([current-reference-compilers binding-compilers])
+         (let-values ([(_ v)
+                       (syntax-local-expand-expression
+                        #'(let () body ...)
+                        #t)])
+           v))])))
+
+(define-syntax #%host-expression
+  (let ([who 'host-expr])
+    (syntax-parser
+      [(_ e:expr)
+       (unless (suspension? this-syntax)
+         (raise-syntax-error who "can only resume a host expansion suspension value" #'e))
+       (define ctx (car (syntax-property this-syntax suspension-property-key)))
+       (local-expand #'e
                      'expression
                      '()
-                     ctx))]))
+                     ctx)])))

--- a/scribblings/bindingspec.scrbl
+++ b/scribblings/bindingspec.scrbl
@@ -136,15 +136,6 @@
 
 @subsection{Compilation}
 
-
-@subsubsection{Compiling host sub-terms}
-
-@defform[(resume-host-expansion stx maybe-reference-compilers)
-         #:grammar ([maybe-reference-compilers
-                     (code:line #:reference-compilers ([binding-class-id transformer] ...))
-                     (code:line)])
-         #:contracts ([stx syntax?] [transformer (or/c set!-transformer? (-> syntax? syntax?))])]
-
 @subsubsection{Persistent free-identifier tables}
 
 @require[(for-label syntax/id-table)]
@@ -180,6 +171,8 @@
 @defthing[immutable-reference-compiler set!-transformer?]
 
 @defthing[mutable-reference-compiler set!-transformer?]
+
+@defform[(with-reference-compilers ([binding-class-id reference-compiler-expr] ...) body ...+)]
 
 @subsubsection{Binding spaces}
 

--- a/test/dsls/minikanren-binding-space-compile.rkt
+++ b/test/dsls/minikanren-binding-space-compile.rkt
@@ -22,10 +22,8 @@
       [n:number
        #'n]
       [((~space-literal rkt mk) e)
-       (resume-host-expansion
-        #'e
-        #:reference-compilers ([term-variable
-                                immutable-reference-compiler]))])))
+       #'(with-reference-compilers ([term-variable immutable-reference-compiler])
+         e)])))
 
 (define-host-interface/expression
   (run n:expr (qvar:term-variable ...)

--- a/test/dsls/minikanren-compile-defs.rkt
+++ b/test/dsls/minikanren-compile-defs.rkt
@@ -24,9 +24,8 @@
       [n:number
        #'n]
       [(rkt e)
-       (resume-host-expansion
-        #'e
-        #:reference-compilers ([term-variable immutable-reference-compiler]))])))
+       #'(with-reference-compilers ([term-variable immutable-reference-compiler])
+        e)])))
 
 (define-host-interface/expression
   (run n:expr (qvar:term-variable ...)

--- a/test/dsls/minikanren-compile.rkt
+++ b/test/dsls/minikanren-compile.rkt
@@ -22,9 +22,8 @@
       [n:number
        #'n]
       [(rkt e)
-       (resume-host-expansion #'e
-                              #:reference-compilers
-                              ([term-variable immutable-reference-compiler]))])))
+       #'(with-reference-compilers ([term-variable immutable-reference-compiler])
+         e)])))
 
 (define-host-interface/expression
   (run n:expr (qvar:term-variable ...)

--- a/test/dsls/minikanren-rs2e/mk.rkt
+++ b/test/dsls/minikanren-rs2e/mk.rkt
@@ -232,9 +232,8 @@
        
        (define/syntax-parse (e-resume ...)
          (for/list ([e (attribute e)])
-           (resume-host-expansion
-            e
-            #:reference-compilers ([term-variable term-reference-compiler]))))
+           #`(with-reference-compilers ([term-variable term-reference-compiler])
+               #,e)))
        #`(lambda (s)
            (let ([compiled-x-projected (walk* compiled-x-ref s)] ...)
              ((conj-gen (check-goal e-resume #'e) ...) s)))]

--- a/test/dsls/statecharts/statecharts.rkt
+++ b/test/dsls/statecharts/statecharts.rkt
@@ -159,11 +159,9 @@
         [_ (rt:no-transition)]))
 
   (define (compile-host-expression stx)
-    (resume-host-expansion
-     stx
-     #:reference-compilers
-     ([data-var immutable-reference-compiler]
-      [local-var immutable-reference-compiler])))
+    #`(with-reference-compilers ([data-var immutable-reference-compiler]
+                                 [local-var immutable-reference-compiler])
+        #,stx))
 
   (define (action-expr-bindings action-expr)
     (syntax-parse action-expr

--- a/test/errors.rkt
+++ b/test/errors.rkt
@@ -374,9 +374,9 @@
 (define-host-interface/expression
   (dsl/let x:dsl-var2 e:expr)
   #:binding {(bind x) (host e)}
-  (resume-host-expansion #'e))
+  #'e)
 
-;; When no reference compiler is provided to resume-host-expansion for
+;; When no reference compiler is provided for
 ;; a given binding class, references to those bindings from a host
 ;; expression are illegal.
 (check-syntax-error
@@ -389,7 +389,7 @@
   ->
   (define
     [(generate-temporary)]
-    [(resume-host-expansion #'e)]))
+    [#'e]))
 
 ;; References to DSL vars bound in host contexts from racket expressions
 ;; are currently always illegal. There should eventually be a way to define


### PR DESCRIPTION
resume-host-expansion is now implicit.

reference compilers can be customized via
`with-reference-compilers`.

tests and documentation need updating
